### PR TITLE
Use pagy_cursor in place of cursor_pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 0.3.3 (Next)
 
 * Your contribution here.
+* [#18](https://github.com/slack-ruby/slack-ruby-bot-server-events/pull/18): Use pagy_cursor in place of cursor_pagination - [@duffn](https://github.com/duffn).
 
 #### 0.3.2 (2022/06/09)
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ when 'activerecord' then
   gem 'activerecord'
   gem 'otr-activerecord'
   gem 'virtus'
-  gem 'cursor_pagination', github: 'dblock/cursor_pagination', branch: 'misc' # rubocop:disable Bundler/OrderedGems
+  gem 'pagy_cursor'
   gem 'pg'
 when nil
   warn "Missing ENV['DATABASE_ADAPTER']."

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,9 @@ when 'mongoid' then
 when 'activerecord' then
   gem 'activerecord'
   gem 'otr-activerecord'
-  gem 'virtus'
   gem 'pagy_cursor'
   gem 'pg'
+  gem 'virtus'
 when nil
   warn "Missing ENV['DATABASE_ADAPTER']."
 else


### PR DESCRIPTION
Current tests on master.

```
 An error occurred while loading ./spec/slack-ruby-bot-server-events/api/endpoints/slack/actions_endpoint_spec.rb. - Did you mean?
                    rspec ./spec/slack-ruby-bot-server-events/api/endpoints/slack/commands_endpoint_spec.rb
                    rspec ./spec/slack-ruby-bot-server-events/api/endpoints/slack/events_endpoint_spec.rb

Failure/Error: require 'slack-ruby-bot-server'

LoadError:
  cannot load such file -- pagy
# ./lib/slack-ruby-bot-server-events.rb:3:in `require'
# ./lib/slack-ruby-bot-server-events.rb:3:in `<top (required)>'
# ./spec/spec_helper.rb:6:in `<top (required)>'
# ./spec/slack-ruby-bot-server-events/api/endpoints/slack/actions_endpoint_spec.rb:3:in `require'
# ./spec/slack-ruby-bot-server-events/api/endpoints/slack/actions_endpoint_spec.rb:3:in `<top (required)>'
```

`pagy_cursor` is required in `slack_ruby_bot_server` as of https://github.com/slack-ruby/slack-ruby-bot-server/pull/158